### PR TITLE
update ncurses source location

### DIFF
--- a/busybox.yaml
+++ b/busybox.yaml
@@ -1,6 +1,6 @@
 package:
   name: busybox
-  version: 1.35.0
+  version: 1.36.1
   epoch: 1
   description: "swiss-army knife for embedded systems"
   target-architecture:
@@ -51,8 +51,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://distfiles.alpinelinux.org/distfiles/edge/busybox-1.35.0.tar.bz2
-      expected-sha256: faeeb244c35a348a334f4a59e44626ee870fb07b6884d68c10ae8bc19f83a694
+      uri: https://distfiles.alpinelinux.org/distfiles/edge/busybox-${{package.version}}.tar.bz2
+      expected-sha256: b8cc24c9574d809e7279c3be349795c5d5ceb6fdf19ca709f80cde50e47de314
   - name: Configure
     runs: |
       cp busyboxconfig .config

--- a/ncurses.yaml
+++ b/ncurses.yaml
@@ -1,6 +1,6 @@
 package:
   name: ncurses
-  version: 6.3
+  version: 6.4
   epoch: 0
   description: "console display library"
   target-architecture:
@@ -41,9 +41,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-#      uri: https://invisible-mirror.net/archives/ncurses/current/ncurses-${{package.version}}-20220820.tgz
-      uri: https://distfiles.alpinelinux.org/distfiles/edge/ncurses-${{package.version}}-20220820.tgz
-      expected-sha256: 7b810b01f71609fd31107a0b7794d0940d3ecc10c98ba19e83749419ba0934b9
+      uri: https://distfiles.alpinelinux.org/distfiles/edge/ncurses-${{package.version}}-20230715.tgz
+      expected-sha256: 7a8dc72f7021815ac7d594e9bd74fc13b20ec4d84295e60c04163197e28aada7
   - name: Configure
     runs: |
         ./configure \


### PR DESCRIPTION
```
Error: got 404 Not Found when fetching https://distfiles.alpinelinux.org/distfiles/edge/ncurses-6.3-20220820.tgz
```

The file seems to have gone missing, this replaces it with the latest [ncurses-6.4-20230715.tgz](https://distfiles.alpinelinux.org/distfiles/edge/ncurses-6.4-20230715.tgz)